### PR TITLE
fix: arguments name and prototype

### DIFF
--- a/service/deploy/k8s.py
+++ b/service/deploy/k8s.py
@@ -20,7 +20,7 @@ DEFAULT_CONFIG_YAML = "config.yaml"
 TIMEOUT = 10
 
 
-def deploy_handle(prompt: str, file: str) -> CodeResponse:
+def deploy_handle(prompt: str, filename: str, file_content: str) -> CodeResponse:
     """
     Handle deployment request:
       1. Extract code content from the file.
@@ -30,14 +30,15 @@ def deploy_handle(prompt: str, file: str) -> CodeResponse:
 
     Args:
         prompt (str): Deployment prompt message.
-        file (str): The path of the file from which to extract code.
+        filename (str): The path of the file from which to extract code.
+        file_content (str): The content of the file.
 
     Returns:
         CodeResponse: A response object containing deployment status, logs, and file information.
     """
     # Extract code content from the file
-    code_content = code_extract(file=file)
-    dockerfile_content = generate_dockerfile(filename=file, code_content=code_content)
+    code_content = code_extract(filename=filename, code_content=file_content)
+    dockerfile_content = generate_dockerfile(filename=filename, code_content=code_content)
     config_yaml_content = generate_config_yaml(prompt=prompt)
     
     # Create a K8s service and perform deployment

--- a/service/deploy/utils.py
+++ b/service/deploy/utils.py
@@ -2,10 +2,7 @@ from typing import List
 
 from utils.llm import OpenAIChat
 
-def code_extract(filename: str) -> str:
-    with open(filename, "r", encoding="utf-8") as f:
-        code_content = f.read()
-        
+def code_extract(filename: str, code_content: str) -> str:        
     response = OpenAIChat.chat(
         dev_prompt="""
         Please only give me the code content from the source code.


### PR DESCRIPTION
This pull request includes changes to the `service/deploy` module to improve the handling of file content during deployment. The most important changes involve modifying function signatures and updating the logic for extracting code content.

Changes to function signatures:

* [`service/deploy/k8s.py`](diffhunk://#diff-08a177937a7afab849f6962240f9a19fed513e70b5d39b2db61fa3eee99a9896L23-R23): Modified the `deploy_handle` function to accept `filename` and `file_content` parameters instead of `file`. [[1]](diffhunk://#diff-08a177937a7afab849f6962240f9a19fed513e70b5d39b2db61fa3eee99a9896L23-R23) [[2]](diffhunk://#diff-08a177937a7afab849f6962240f9a19fed513e70b5d39b2db61fa3eee99a9896L33-R41)
* [`service/deploy/utils.py`](diffhunk://#diff-9f5263b62b538415f935b4e9b8eb13a7272a1c2c798bd6038791912827d9163aL5-R5): Updated the `code_extract` function to accept `filename` and `code_content` parameters.

Updates to code extraction logic:

* [`service/deploy/k8s.py`](diffhunk://#diff-08a177937a7afab849f6962240f9a19fed513e70b5d39b2db61fa3eee99a9896L33-R41): Adjusted the logic in `deploy_handle` to use the new parameters `filename` and `code_content` when calling `code_extract` and `generate_dockerfile`.
* [`service/deploy/utils.py`](diffhunk://#diff-9f5263b62b538415f935b4e9b8eb13a7272a1c2c798bd6038791912827d9163aL5-R5): Removed file reading logic from `code_extract` since the content is now passed directly as a parameter.